### PR TITLE
Fix: Equipped items not displaying in client

### DIFF
--- a/Server/Systems/026-EquipSystem.cs
+++ b/Server/Systems/026-EquipSystem.cs
@@ -62,6 +62,9 @@ public sealed class EquipSystem : NttSystem<InventoryComponent, EquipmentCompone
             var msg = MsgItem.EquipItem(newItemNtt, change.Slot);
             ntt.NetSync(ref msg);
 
+            var itemInfoMsg = MsgItemInformation.Create(newItemNtt, MsgItemInfoAction.AddItem, change.Slot);
+            ntt.NetSync(ref itemInfoMsg);
+
             if (IsLogging)
                 FConsole.WriteLine("{ntt} equipped {item} to slot {slot}", ntt, newItemNtt, change.Slot);
         }


### PR DESCRIPTION
The client was not receiving full item information when an item was equipped, causing it to not display the item.

This change modifies the `EquipSystem` to send a `MsgItemInformation` packet, in addition to the existing `MsgItem` packet, when an item is equipped. This provides the client with all necessary item details to display it correctly.